### PR TITLE
fix: width of contributors on Firefox

### DIFF
--- a/components/home/HomeContributors.vue
+++ b/components/home/HomeContributors.vue
@@ -17,7 +17,7 @@
                     'transition-delay': `${(index % 8 + Math.floor(index / 8)) * 20}ms`
                 }"
                 >
-                <UTooltip :text="contributor.username">
+                <UTooltip class="w-full" :text="contributor.username">
                     <NuxtImg
                     :src="`/gh_avatar/${contributor.username}`"
                     provider="ipx"


### PR DESCRIPTION
On Firefox right now
![image](https://github.com/nuxt/nuxters/assets/640208/78e46e3a-9727-46e7-98ea-4809c6e3be6d)

After the fix:
![image](https://github.com/nuxt/nuxters/assets/640208/ea6e7a89-26fb-4f6a-a75a-5ccb61fd2bce)
