### PR TITLE
fix: null safety for slicing contributors

### DIFF
--- a/components/home/HomeContributors.vue
+++ b/components/home/HomeContributors.vue
@@ -53,6 +53,6 @@
     };
 
     const contributors = computed(() => {
-        return allContributors.value.slice(0, limit.value)
+        return allContributors.value?.slice(0, limit.value)
     })
 </script>

--- a/components/home/HomeContributors.vue
+++ b/components/home/HomeContributors.vue
@@ -53,6 +53,6 @@
     };
 
     const contributors = computed(() => {
-        return allContributors.value?.slice(0, limit.value)
+        return allContributors.value?.slice(0, limit.value) || []
     })
 </script>


### PR DESCRIPTION
when navigating from another route to `/`, it cause this
<img width="503" alt="Screenshot 2024-04-22 at 11 47 04 AM" src="https://github.com/nuxt/nuxters/assets/38922203/079ecb58-86e3-4119-8a32-26915107f17a">
