### PR TITLE
fix: og image cards overflow

### DIFF
--- a/components/OgImage/OgImageNuxter.vue
+++ b/components/OgImage/OgImageNuxter.vue
@@ -10,7 +10,7 @@ const format = useNumberFormatter()
 </script>
 
 <template>
-  <div class="flex flex-row justify-between w-full p-[38px] bg-[#0f172a]">
+  <div class="flex flex-row justify-between w-full h-full p-[38px] bg-[#0f172a]">
     <div class="flex flex-col w-1/3 items-center py-10 justify-between text-white">
       <div class="flex flex-col items-center">
         <UAvatar :src="`https://avatars.githubusercontent.com/u/${contributor.githubId}`" size="3xl"

--- a/components/OgImage/OgImageNuxter.vue
+++ b/components/OgImage/OgImageNuxter.vue
@@ -10,7 +10,7 @@ const format = useNumberFormatter()
 </script>
 
 <template>
-  <div class="flex flex-row justify-between w-full h-full p-[38px] bg-[#0f172a]">
+  <div class="flex flex-row justify-between w-full h-full p-[38px] bg-gray-900">
     <div class="flex flex-col w-1/3 items-center py-10 justify-between text-white">
       <div class="flex flex-col items-center">
         <UAvatar :src="`https://avatars.githubusercontent.com/u/${contributor.githubId}`" size="3xl"
@@ -40,7 +40,7 @@ const format = useNumberFormatter()
           </svg>
           <div class="font-medium text-4xl pl-2 pt-1">{{ format(contributor.score) }}</div>
         </div>
-        <div class="flex flex-row text-[#94a3b8] items-center pt-3 font-medium text-3xl">
+        <div class="flex flex-row text-gray-400 items-center pt-3 font-medium text-3xl">
           #{{ format(contributor.rank) }}
         </div>
       </div>

--- a/components/OgImage/OgImageNuxter.vue
+++ b/components/OgImage/OgImageNuxter.vue
@@ -10,7 +10,7 @@ const format = useNumberFormatter()
 </script>
 
 <template>
-  <div class="flex flex-row justify-between w-full p-[38px] bg-gray-900">
+  <div class="flex flex-row justify-between w-full p-[38px] bg-[#0f172a]">
     <div class="flex flex-col w-1/3 items-center py-10 justify-between text-white">
       <div class="flex flex-col items-center">
         <UAvatar :src="`https://avatars.githubusercontent.com/u/${contributor.githubId}`" size="3xl"
@@ -40,7 +40,7 @@ const format = useNumberFormatter()
           </svg>
           <div class="font-medium text-4xl pl-2 pt-1">{{ format(contributor.score) }}</div>
         </div>
-        <div class="flex flex-row text-gray-400 items-center pt-3 font-medium text-3xl">
+        <div class="flex flex-row text-[#94a3b8] items-center pt-3 font-medium text-3xl">
           #{{ format(contributor.rank) }}
         </div>
       </div>

--- a/components/islands/CommentsCard.vue
+++ b/components/islands/CommentsCard.vue
@@ -5,7 +5,7 @@ const format = useNumberFormatter()
 </script>
 
 <template>
-  <div class="rounded-xl border p-6 text-center flex flex-col items-center justify-end relative h-full border-blue-400">
+  <div class="rounded-xl border p-6 text-center flex flex-col items-center justify-end relative h-full border-blue-400 overflow-hidden">
     <div class="absolute top-0 left-0 right-0">
       <svg xmlns="http://www.w3.org/2000/svg" width="398" height="263" fill="none">
         <g filter="url(#a)">

--- a/components/islands/IssuesCard.vue
+++ b/components/islands/IssuesCard.vue
@@ -6,7 +6,7 @@ const format = useNumberFormatter()
 
 <template>
   <div
-    class="rounded-xl border p-6 text-center flex flex-col items-center justify-end relative h-full border-green-400">
+    class="rounded-xl border p-6 text-center flex flex-col items-center justify-end relative h-full border-green-400 overflow-hidden">
     <div class="absolute top-0 left-0 right-0">
       <svg xmlns="http://www.w3.org/2000/svg" width="352" height="263" fill="none">
         <g filter="url(#a)">

--- a/components/islands/PullRequestCard.vue
+++ b/components/islands/PullRequestCard.vue
@@ -6,7 +6,7 @@ const format = useNumberFormatter()
 </script>
 
 <template>
-  <div class="rounded-xl border p-6 text-center flex flex-col items-center justify-end relative h-full border-violet-400">
+  <div class="rounded-xl border p-6 text-center flex flex-col items-center justify-end relative h-full border-violet-400 overflow-hidden">
     <div class="absolute top-0 left-0 right-0">
       <svg xmlns="http://www.w3.org/2000/svg" width="456" height="263" fill="none">
         <g filter="url(#a)">

--- a/components/islands/ReactionsCard.vue
+++ b/components/islands/ReactionsCard.vue
@@ -6,7 +6,7 @@ const format = useNumberFormatter();
 </script>
 
 <template>
-  <div class="rounded-xl border p-6 text-center flex flex-col items-center justify-end relative h-full border-yellow-400">
+  <div class="rounded-xl border p-6 text-center flex flex-col items-center justify-end relative h-full border-yellow-400 overflow-hidden">
     <div class="absolute top-0 left-0 right-0">
       <svg xmlns="http://www.w3.org/2000/svg" width="354" height="260" fill="none">
         <g filter="url(#a)">


### PR DESCRIPTION
### 🔗 Linked issue

resolves #88 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

~~I'm not a Tailwind expert but it seems like the og module is not seeing the colors when using classes like `bg-gray-900`, `text-gray-400` so instead I used [Arbitrary values](https://tailwindcss.com/docs/text-color#arbitrary-values). If someone knows how to make the color classes work the help is welcomed!~~

And for fixing the overflowing I simply added the `overflow-hidden` tailwing class to each card

The image below is how it looks with the changes

![image](https://github.com/user-attachments/assets/553b1859-6f0c-4437-a6c7-df01b4ca72a2)


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
