### PR TITLE
fix: h3 future compat

### DIFF
--- a/server/plugins/compat.ts
+++ b/server/plugins/compat.ts
@@ -2,9 +2,9 @@ import { getRequestHeader } from 'h3'
 
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('request', async (event) => {
-    if (typeof event.req.headers.get === 'undefined') {
-      // @ts-expect-error support newer version of h3
-      event.req.headers.get = getRequestHeader.bind(null, event)
+    if (typeof event.req.headers.get !== 'function') {
+      // @ts-expect-error cross-version compat between h3 request header types
+      event.req.headers.get = (name: string) => getRequestHeader(event, name) ?? null
     }
   })
 })

--- a/server/plugins/compat.ts
+++ b/server/plugins/compat.ts
@@ -1,0 +1,10 @@
+import { getRequestHeader } from 'h3'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('request', async (event) => {
+    if (typeof event.req.headers.get === 'undefined') {
+      // @ts-expect-error support newer version of h3
+      event.req.headers.get = getRequestHeader.bind(null, event)
+    }
+  })
+})


### PR DESCRIPTION
Should prevent this error with Nuxt v4 and dependencies using h3 v2:

```
TypeError: event.req.headers.get is not a function
    at getRequestHost (file:///var/task/chunks/nitro/nitro.mjs:6654:45)
```