### PR TITLE
fix: trace harfbuzzjs wasm into the server bundle

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,9 @@
+import { createRequire } from 'node:module'
 import { defineNuxtConfig } from 'nuxt/config'
+
+const require = createRequire(import.meta.url)
+// satori >= 0.30 shapes text with harfbuzzjs, whose wasm is loaded at runtime and not traced into the server bundle
+const harfbuzzWasm = createRequire(require.resolve('satori')).resolve('harfbuzzjs/hb.wasm')
 
 export default defineNuxtConfig({
   modules: [
@@ -51,6 +56,9 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-31',
 
   nitro: {
+    externals: {
+      traceInclude: [harfbuzzWasm],
+    },
     storage: {
       cache: {
         driver: 'http',


### PR DESCRIPTION
The og image cards have been returning a 500 in production for every user since #427 bumped satori from 0.29 to 0.33. satori now shapes text with harfbuzzjs, which loads `hb.wasm` from disk at runtime, and Nitro's file tracing doesn't pick that file up:

```
ENOENT: no such file or directory, open '/var/task/node_modules/harfbuzzjs/hb.wasm'
```

This resolves the wasm from satori's own `node_modules` and adds it to `nitro.externals.traceInclude`. Checked with a `NITRO_PRESET=vercel` build that the file now lands in `__fallback.func/node_modules/harfbuzzjs/`, and the node-server build renders `/_og/r/benjamincanac.png` again.